### PR TITLE
Remove unnecessary scopes

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], scope: "read:user, user:email"
+  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"]
   provider :twitter, ENV["TWITTER_KEY"], ENV["TWITTER_SECRET"]
 end


### PR DESCRIPTION
I have tried to login to hackershare.dev without these scopes and found no issue. So I guess these scopes are not really necessary.