### PR TITLE
Refactor the User avatar for get a simple and cacheable image URL

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class UploadsController < ActionController::Base
+  before_action :set_blob
+
+  # A customize uploads path for ActiveStorage
+  #
+  # GET /uplaods/:id?s=<size>
+  #
+  # send file
+  #
+  # Reference implementation
+  # https://github.com/thebluedoc/bluedoc/blob/7efc1c5c3878a4d63bcaed7294c87ff30dc2c2a7/app/controllers/blobs_controller.rb
+  def show
+    send_file_by_disk_key @blob, content_type: @blob.content_type
+  rescue ActionController::MissingFile, ActiveStorage::FileNotFoundError
+    head :not_found
+  rescue ActiveStorage::IntegrityError
+    head :unprocessable_entity
+  end
+
+  private
+
+    def send_file_by_disk_key(blob, content_type:)
+      expires_in 1.year
+
+      blob_key = blob.key
+
+      if params[:s]
+        blob_key = @blob.representation(Hackershare::Blob.variation(params[:s])).processed.key
+      end
+
+      blob_path = ActiveStorage::Blob.service.send(:path_for, blob_key)
+
+      send_file blob_path, type: content_type, disposition: :inline
+    end
+
+
+    def set_blob
+      @blob = Rails.cache.fetch("blobs:#{params[:id]}") do
+        ActiveStorage::Blob.find_by(key: params[:id])
+      end
+
+      head :not_found if @blob.blank?
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,11 @@
 class User < ApplicationRecord
   RSS_BOT_NAME  = "hackershare"
   RSS_BOT_EMAIL = "robot@hackershare.dev"
+
+  include User::Avatar
+
   has_secure_password
-  has_one_attached :avatar
+
   has_many :auth_providers, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_bookmarks, through: :likes, source: "bookmark"
@@ -94,14 +97,6 @@ class User < ApplicationRecord
 
   def username
     read_attribute(:username) || email.split("@")[0]
-  end
-
-  def avatar_url
-    if avatar.attached?
-      avatar.variant(resize_to_limit: [150, nil])
-    else
-      ["https://www.gravatar.com/avatar", Digest::MD5.hexdigest(email)].join("/")
-    end
   end
 
   def has_unread_notifications?

--- a/app/models/user/avatar.rb
+++ b/app/models/user/avatar.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class User
+  module Avatar
+    extend ActiveSupport::Concern
+
+    included do
+      has_one_attached :avatar
+    end
+
+    def avatar_url(size: :md)
+      if !avatar_attached?
+        return ["https://www.gravatar.com/avatar", Digest::MD5.hexdigest(email)].join("/")
+      end
+
+      Rails.cache.fetch([cache_key_with_version, "avatar_url", size]) do
+        Rails.application.routes.url_helpers.upload_url(avatar.blob.key, s: size)
+      end
+    end
+
+    def avatar_attached?
+      Rails.cache.fetch([cache_key_with_version, "avatar_attached"]) do
+        avatar.attached?
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,10 @@ module Hackershare
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.autoload_paths += [
+      Rails.root.join("lib")
+    ]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/deploy/templates/nginx_conf.erb
+++ b/config/deploy/templates/nginx_conf.erb
@@ -62,7 +62,7 @@ server {
     error_log <%= shared_path %>/log/nginx.error.log;
   }
 
-  location ^~ /assets/ {
+  location ~ ^(/packs|/assets|/uploads) {
     gzip_static on;
     expires max;
     add_header Cache-Control public;

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-Rails.application.routes.default_url_options[:host] = if Rails.env.development?
-  "localhost:3000"
-elsif Rails.env.test?
-  "localhost:3000"
-elsif Rails.env.production?
-  "hackershare.dev"
-end
-
 # NOTICE: http://lulalala.logdown.com/posts/5835445-rails-many-default-url-options
-Rails.application.routes.default_url_options[:protocol] = "https"
+if Rails.env.production?
+  Rails.application.routes.default_url_options[:host] = "hackershare.dev"
+  Rails.application.routes.default_url_options[:protocol] == "https"
+else
+  Rails.application.routes.default_url_options[:host] = "localhost:3000"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # short upload file url
+  get "/uploads/:id" => "uploads#show", as: :upload
+
   scope "(:locale)", locale: /cn/ do
     resources :registrations, only: %i[new create]
     resources :sessions, only: %i[new create]

--- a/lib/hackershare/blob.rb
+++ b/lib/hackershare/blob.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hackershare
+  # A ActiveStorage Blob helper
+  # To convert image thumb name into Active Storage Variation
+  #
+  # https://github.com/thebluedoc/bluedoc/blob/7efc1c5c3878a4d63bcaed7294c87ff30dc2c2a7/lib/bluedoc/blob.rb
+  class Blob
+    class << self
+      IMAGE_SIZES = { sm: 64, md: 150, lg: 440, xl: 1600 }
+
+      # convert image thumb name into Active Storage Variation
+      def variation(size)
+        ActiveStorage::Variation.new(combine_options(size))
+      end
+
+      private
+
+        def combine_options(size)
+          size = size&.to_sym
+          width = IMAGE_SIZES[size] || IMAGE_SIZES[:md]
+
+          if size == :xl
+            { resize: "#{width}>" }
+          else
+            { thumbnail: "#{width}x#{width}^", gravity: "center", extent: "#{width}x#{width}" }
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
Refactor the User avatar for get a simple and cacheable image URL `/uploads/:id`, and thumb version as `s` param.

For example:

GET /uploads/42ng1w6kkhve1ezzzqizc1eaghd4?s=md

Fix Nginx config for give `/packs`, `/uploads` a long term cache period.

<img width="632" alt="截屏2020-09-30 14 47 09" src="https://user-images.githubusercontent.com/5518/94651966-dbbce980-032b-11eb-91d1-ac106471d19a.png">
