### PR TITLE
weekly selection admin

### DIFF
--- a/app/controllers/admin/weekly_selections_controller.rb
+++ b/app/controllers/admin/weekly_selections_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Admin::WeeklySelectionsController < Admin::ApplicationController
+  def index
+    @weekly_selection = WeeklySelection.unpublished.order(:id).includes(:bookmarks).find_or_create_by!({})
+  end
+
+  def publish
+    @weekly_selection = WeeklySelection.find(params[:id])
+    if @weekly_selection.bookmarks_count != WeeklySelection::BOOKMARKS_COUNT
+      raise ValidateError, "The bookmarks count of publishing weekly selection should be equal #{WeeklySelection::BOOKMARKS_COUNT}"
+    end
+    @weekly_selection.update!(weekly_selection_params)
+    flash[:success] = "Published successfully."
+    redirect_back fallback_location: root_path
+  rescue ValidateError, ActiveRecord::RecordInvalid => e
+    flash[:error] = e.message
+    redirect_back fallback_location: root_path
+  end
+
+  def titling
+    @weekly_selection = WeeklySelection.find(params[:id])
+    @bookmark = Bookmark.find(params[:bookmark_id])
+    @weekly_selection.update!(title: @bookmark.title)
+    flash[:success] = "Change weekly selection title successfully."
+    redirect_back fallback_location: root_path
+  rescue ValidateError, ActiveRecord::RecordInvalid => e
+    flash[:error] = e.message
+    redirect_back fallback_location: root_path
+  end
+
+  private
+
+    def weekly_selection_params
+      params.require(:weekly_selection).permit(
+        :published_at,
+        :title,
+        :description,
+        :description_en,
+      )
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  class ValidateError < StandardError; end
+
   include Pagy::Backend
   around_action :switch_locale
   before_action :authenticate_user!
@@ -100,7 +102,7 @@ class ApplicationController < ActionController::Base
     def render_bookmarks
       @tag = params[:tag]
       @query = Util.escape_quote(params[:query]) if params[:query]
-      base = Bookmark.includes(:pinned_comment, :tags).display.sorting(params).original.preload(:user, :tags)
+      base = Bookmark.includes(:pinned_comment, :tags, :weekly_selection).display.sorting(params).original.preload(:user, :tags)
       base = base.tag_filter(base, @tag) if @tag.present?
       user_lang = current_user.bookmark_lang if user_signed_in?
       @lang = (["language"] + Bookmark.langs.keys).include?(params[:lang]) ? params[:lang] : user_lang

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -72,7 +72,29 @@ class BookmarksController < ApplicationController
     render layout: false
   end
 
-  def bookmark_params
-    params.require(:bookmark).permit(:url)
+  def weekly_select
+    @bookmark = Bookmark.find(params[:id])
+    raise ValidateError, "No permission" unless @bookmark.can_set_selection?(current_user)
+    if @bookmark.weekly_selected?
+      @bookmark.update!(weekly_selection_id: nil)
+      flash[:success] = "Cancel weekly selection successfully."
+    else
+      weekly_selection = WeeklySelection.unpublished.order(:id).find_or_create_by!({})
+      if weekly_selection.bookmarks_count >= WeeklySelection::BOOKMARKS_COUNT
+        raise ValidateError, "The count of next weekly selection is enough, you can manage bookmarks in the admin console."
+      end
+      @bookmark.update!(weekly_selection_id: weekly_selection.id)
+      flash[:success] = "Add weekly selection successfully."
+    end
+    redirect_back fallback_location: root_path
+  rescue ValidateError, ActiveRecord::RecordInvalid => e
+    flash[:error] = e.message
+    redirect_back fallback_location: root_path
   end
+
+  private
+
+    def bookmark_params
+      params.require(:bookmark).permit(:url)
+    end
 end

--- a/app/controllers/weekly_selections_controller.rb
+++ b/app/controllers/weekly_selections_controller.rb
@@ -4,17 +4,12 @@ class WeeklySelectionsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @weekly_selection = WeeklySelection.includes(:bookmarks).last
-    if @weekly_selection
-      @last_weekly_selection = WeeklySelection.find_by("id < ?", @weekly_selection.id)
-      @next_weekly_selection = WeeklySelection.find_by("id > ?", @weekly_selection.id)
-    end
-    render :show
+    @weekly_selections = WeeklySelection.published.order(id: :desc).limit(100)
   end
 
   def show
-    @weekly_selection = WeeklySelection.includes(:bookmarks).find(params[:id])
-    @last_weekly_selection = WeeklySelection.find_by("id < ?", @weekly_selection.id)
-    @next_weekly_selection = WeeklySelection.find_by("id > ?", @weekly_selection.id)
+    @weekly_selection = WeeklySelection.published.includes(:bookmarks).find(params[:id])
+    @last_weekly_selection = WeeklySelection.published.order(id: :desc).find_by("id < ?", @weekly_selection.id)
+    @next_weekly_selection = WeeklySelection.published.order(:id).find_by("id > ?", @weekly_selection.id)
   end
 end

--- a/app/javascript/css/components.scss
+++ b/app/javascript/css/components.scss
@@ -58,3 +58,8 @@
 .btn-tag:hover {
   @apply bg-gray-200;
 }
+
+.field-required:after {
+  content:" *";
+  color: red;
+}

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -135,6 +135,11 @@ class Bookmark < ApplicationRecord
     created_by?(user) || user.admin?
   end
 
+  def can_set_selection?(user)
+    return unless user
+    user.admin? && !weekly_selection&.published?
+  end
+
   def only_first
     ref || self
   end
@@ -235,8 +240,12 @@ class Bookmark < ApplicationRecord
     notifications.destroy_all
   end
 
-  def weekly_selection?
-    !weekly_selection_id.nil?
+  def weekly_selected?
+    weekly_selection_id.present?
+  end
+
+  def weekly_selection_title?
+    (title&.size || 0).in?(8..48)
   end
 
   private

--- a/app/models/weekly_selection.rb
+++ b/app/models/weekly_selection.rb
@@ -8,9 +8,27 @@
 #  bookmarks_count :integer          default(0)
 #  description     :text
 #  description_en  :text
+#  published_at    :datetime
+#  title           :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
 class WeeklySelection < ApplicationRecord
+  BOOKMARKS_COUNT = 5
   has_many :bookmarks
+  validates :title, :description, :description_en, presence: true, if: :published?
+  scope :unpublished, lambda { where(published_at: nil) }
+  scope :published, lambda { where.not(published_at: nil) }
+
+  def published?
+    published_at.present?
+  end
+
+  def guessed_title
+    bookmarks.select(&:weekly_selection_title?).sort_by(&:smart_score).last&.title
+  end
+
+  def full_title
+    "#{title} | #{I18n.t("issue_no", no: id)}"
+  end
 end

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -51,6 +51,15 @@
                     RSS Bookmarks
                   </a>
 
+                  <a href="<%= admin_weekly_selections_path %>" class="group flex items-center px-2 py-2 text-sm leading-5 font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
+                    <svg class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500 group-focus:text-gray-500 transition ease-in-out duration-150" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path fill="#fff" d="M12 14l9-5-9-5-9 5 9 5z" />
+                      <path fill="#fff" d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
+                    </svg>
+                    Weekly Selections
+                  </a>
+
                   <a href="<%= root_path(locale: (best_locale == I18n.default_locale ? nil : best_locale)) %>" class="group flex items-center px-2 py-2 text-sm leading-5 font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
                     <svg class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500 group-focus:text-gray-500 transition ease-in-out duration-150" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />

--- a/app/views/admin/_nav_mobile.html.erb
+++ b/app/views/admin/_nav_mobile.html.erb
@@ -60,6 +60,15 @@
                     RSS Bookmarks
                   </a>
 
+                  <a href="<%= admin_weekly_selections_path %>" class="group flex items-center px-2 py-2 text-sm leading-5 font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
+                    <svg class="mr-4 h-6 w-6 text-gray-400 group-hover:text-gray-500 group-focus:text-gray-500 transition ease-in-out duration-150" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path fill="#fff" d="M12 14l9-5-9-5-9 5 9 5z" />
+                      <path fill="#fff" d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
+                    </svg>
+                    Weekly Selections
+                  </a>
+
                   <a href="<%= root_path(locale: (best_locale == I18n.default_locale ? nil : best_locale)) %>" class="group flex items-center px-2 py-2 text-sm leading-5 font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
                     <svg class="mr-4 h-6 w-6 text-gray-400 group-hover:text-gray-500 group-focus:text-gray-500 transition ease-in-out duration-150" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />

--- a/app/views/admin/weekly_selections/index.html.erb
+++ b/app/views/admin/weekly_selections/index.html.erb
@@ -1,0 +1,128 @@
+<div class="space-y-8">
+  <%= form_with model: @weekly_selection, method: 'post', local: true, url: publish_admin_weekly_selection_path(@weekly_selection) do |f| %>
+    <div class="shadow sm:rounded-md sm:overflow-hidden">
+      <div class="px-4 py-5 bg-white sm:p-6 space-y-4">
+        <h3 class="text-lg font-medium leading-6 text-gray-900">Pending Weekly Selection</h3>
+        <div>
+          <%= f.label :published_at, class: 'block text-sm font-medium leading-5 text-gray-700' %>
+          <div class="mt-1 rounded-md shadow-sm">
+            <%= f.text_field :published_at, value: @weekly_selection.published_at&.to_date || Time.zone.today, readonly: true, class: 'form-input w-full rounded-md transition duration-150 ease-in-out sm:text-sm sm:leading-5' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :title, class: 'block text-sm font-medium leading-5 text-gray-700 field-required' %>
+          <div class="mt-1 flex rounded-md shadow-sm">
+            <%= f.text_field :title, value: @weekly_selection.title || @weekly_selection.guessed_title, class: 'form-input flex-1 block w-full rounded-none rounded-l-md transition duration-150 ease-in-out sm:text-sm sm:leading-5' %>
+            <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 text-sm">
+              | <%= t("issue_no", no: @weekly_selection.id) %>
+            </span>
+          </div>
+        </div>
+        <div>
+          <%= f.label :description, class: 'block text-sm font-medium leading-5 text-gray-700 field-required' %>
+          <div class="rounded-md shadow-sm">
+            <%= f.text_area :description, rows: '3', class: 'form-textarea mt-1 block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5 field-required' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :description_en, class: 'block text-sm font-medium leading-5 text-gray-700 field-required' %>
+          <div class="rounded-md shadow-sm">
+            <%= f.text_area :description_en, rows: '3', class: 'form-textarea mt-1 block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5 field-required' %>
+          </div>
+        </div>
+        <div>
+          <%= f.submit 'Publish', class: 'btn-primary' %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <div class="flex flex-col">
+    <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+        <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Name
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Score
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Smart Score
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Likes
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Dups
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Comments
+                </th>
+                <th class="p-2 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                  Clicks
+                </th>
+                <th class="px-6 py-3 bg-gray-50"></th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200"> 
+              <% @weekly_selection.bookmarks.each do |bookmark| %>
+                <tr>
+                  <td class="p-2">
+                    <div class="flex items-center">
+                      <div class="flex-shrink-0 h-10 w-10">
+                        <% if bookmark.favicon_local.attached? %>
+                          <span>
+                            <%= image_tag(bookmark.favicon_local.service_url, loading: 'lazy', class: "h-10 w-10") %>
+                          </span>
+                        <% else %>
+                          <span>
+                            <%= lavatar_tag(bookmark.letter_char, 16, class: "w-10 h-10") %>
+                          </span>
+                        <% end %>
+                      </div>
+                      <div class="ml-4">
+                        <div class="text-sm leading-5 font-medium text-gray-900">
+                          <%= bookmark.title %>
+                        </div>
+                        <div class="text-sm leading-5 text-gray-500">
+                          <%= bookmark.url %>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-2">
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                      <%= bookmark.score %>
+                    </span>
+                  </td>
+                  <td class="p-2 text-sm leading-5 text-gray-500">
+                    <%= bookmark.smart_score.round(2) %>
+                  </td>
+                  <td class="p-2 text-sm leading-5 text-gray-500">
+                    <%= bookmark.likes_count %>
+                  </td>
+                  <td class="p-2 text-sm leading-5 text-gray-500">
+                    <%= bookmark.dups_count %>
+                  </td>
+                  <td class="p-2 text-sm leading-5 text-gray-500">
+                    <%= bookmark.comments_count %>
+                  </td>
+                  <td class="p-2 text-sm leading-5 text-gray-500">
+                    <%= bookmark.clicks_count %>
+                  </td>
+                  <td class="p-2 text-right text-sm leading-5 font-medium">
+                    <%= link_to 'Cancel', weekly_select_bookmark_path(bookmark), method: :patch, class: 'text-indigo-600 hover:text-indigo-900', 'data-confirm': 'Are you sure?' %>
+                    <%= link_to 'Titling', titling_admin_weekly_selection_path(@weekly_selection, bookmark_id: bookmark.id), method: :patch, class: 'text-indigo-600 hover:text-indigo-900' %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -13,7 +13,7 @@
         <span class="block break-all">
           <h2 class="text-md font-medium leading-5">
             <span class="align-middle"><%= bookmark.title_or_url %></span>
-            <% if bookmark.weekly_selection? %>
+            <% if bookmark.weekly_selected? %>
               <svg class="w-5 h-5 inline align-middle text-orange-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z" />
               </svg>
@@ -77,7 +77,7 @@
             </svg>
           </a>
         </div>
-        <div x-show="open" x-description="Profile dropdown panel, show/hide based on dropdown state." x-transition:enter="transition ease-out duration-100" x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100" x-transition:leave-end="transform opacity-0 scale-95" class="mt-1 w-32 origin-top-right absolute right-0 rounded-md shadow-lg z-10" style="display: none;">
+        <div x-show="open" x-description="Profile dropdown panel, show/hide based on dropdown state." x-transition:enter="transition ease-out duration-100" x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100" x-transition:leave-end="transform opacity-0 scale-95" class="mt-1 w-44 origin-top-right absolute right-0 rounded-md shadow-lg z-10" style="display: none;">
           <div class="py-1 rounded-md bg-white shadow-xs" role="menu" aria-orientation="vertical" aria-labelledby="user-menu">
             <%= link_to new_bookmark_tag_path(bookmark), remote: true, class: "relative flex items-center space-x-1 px-2 py-2 hover:text-gray-800", data: {type: :script, action: "ajax:success->remote-forms#append"} do %>
               <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -98,6 +98,16 @@
               <span><%= t("share_to_telegram") %></span>
             <% end %>
             
+            <% if bookmark_self.can_set_selection?(current_user) %>
+              <%= link_to weekly_select_bookmark_path(bookmark_self), method: :patch, class: "relative flex items-center space-x-1 px-2 py-2 hover:text-gray-800" do %>
+                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path fill="#fff" d="M12 14l9-5-9-5-9 5 9 5z" />
+                  <path fill="#fff" d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
+                </svg>
+                <span><%= bookmark_self.weekly_selected? ? t("selection_cancel") : t("selection_add") %></span>
+              <% end %>
+            <% end %>
             <% if bookmark_self.can_destroy_by?(current_user) %>
               <%= link_to bookmark_path(bookmark_self), method: :delete, remote: true, data: {confirm: t("confirm_delete")}, class: "relative flex items-center space-x-1 px-2 py-2 hover:text-gray-800" do %>
                 <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/views/layouts/_main.html.erb
+++ b/app/views/layouts/_main.html.erb
@@ -1,5 +1,5 @@
-<main class="mt-2 lg:mt-4 min-h-screen">
-  <div class="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
+<main class="mt-2 lg:mt-4">
+  <div class="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8 min-h-screen">
     <%= yield %>
   </div>
 </main>

--- a/app/views/weekly_selections/index.html.erb
+++ b/app/views/weekly_selections/index.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:title, t('weekly_selection')) %>
+
+<div class="space-y-4 lg:space-y-0 lg:flex lg:space-x-4">
+  <div class="lg:flex-auto">
+    <div class="border border-color-primary rounded-primary min-h-screen">
+      <div class="padding-primary bg-primary rounded-t-md border-b border-color-primary">
+        <h3 class="mr-2 text-lg leading-6 font-medium text-gray-900 py-2">
+          <%= t('weekly_selection') %>
+        </h3>
+      </div>
+      <div class="padding-primary space-y-2 lg:space-y-4 divide-y divide-gray-200">
+        <table class="w-full">
+          <tbody>
+            <% @weekly_selections.each do |weekly_selection| %>
+              <tr>
+                <td class="py-2 align-middle">
+                  <span class="px-2 py-1 text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"><%= l weekly_selection.published_at.to_date %></span>
+                </td>
+                <td class="py-2 align-middle">
+                  <%= link_to weekly_selection.full_title, weekly_selection_path(weekly_selection), class: 'text-sm leading-5 font-medium text-gray-900 hover:text-black' %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="lg:flex-shrink-0 lg:w-80">
+    <div class="border border-color-primary rounded-primary">
+      <div class="padding-primary bg-primary rounded-t-md border-b border-color-primary">
+        <h3 class="mr-2 text-lg leading-6 font-medium text-gray-900 py-2">
+          <%= t("weekly_selection_describe") %>
+        </h3>
+      </div>
+      <div class="padding-primary">
+        <div class="text-sm text-gray-500">
+          <%= t("weekly_selection_hint") %>
+        </div>
+        <div class="flex justify-center"><%= image_tag "https://cdn.hackershare.cn/wechat-barcode-hdgcs.jpg" %></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/weekly_selections/show.html.erb
+++ b/app/views/weekly_selections/show.html.erb
@@ -1,7 +1,4 @@
-<% if @weekly_selection %>
-  <% title = "#{t("issue_no", no: @weekly_selection.id)} (#{l @weekly_selection.created_at.to_date})" %>
-  <% content_for(:title, title) %>
-<% end %>
+<% content_for(:title, @weekly_selection&.full_title) %>
 
 <div class="space-y-4 lg:space-y-0 lg:flex lg:space-x-4">
   <div class="lg:flex-auto">
@@ -11,7 +8,8 @@
     <div class="border border-color-primary rounded-primary">
       <div class="padding-primary bg-primary rounded-t-md border-b border-color-primary">
         <h3 class="mr-2 text-lg leading-6 font-medium text-gray-900 py-2">
-          <%= title %>
+          <span><%= @weekly_selection&.full_title %></span>
+          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"><%= l @weekly_selection.published_at.to_date %></span>
         </h3>
         <p class="text-sm text-gray-500"><%= I18n.locale == :en ? @weekly_selection.description_en : @weekly_selection.description %></p>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,8 @@ en:
   save: Save
   search: Search
   search_results: "Search Results: %{query}"
+  selection_add: Add Selection
+  selection_cancel: Cancel Selection
   send: Send
   share_to_twitter: Share to twitter
   share_to_telegram: Share to telegram

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -64,6 +64,8 @@ zh-CN:
   save: 保存
   search: 搜索
   search_results: "搜索结果: %{query}"
+  selection_add: 设置精选
+  selection_cancel: 取消精选
   send: 分享
   share_to_twitter: 分享到推特
   share_to_telegram: 分享到电报群

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,12 @@ Rails.application.routes.draw do
         patch :undisplay
       end
     end
+    resources :weekly_selections, only: %i[index] do
+      member do
+        post :publish
+        patch :titling
+      end
+    end
   end
 
   scope "(:locale)", locale: /en/ do
@@ -70,6 +76,7 @@ Rails.application.routes.draw do
         post :toggle_liking
         get :hover_like_users
         get :goto
+        patch :weekly_select
       end
       resources :comments
       resources :tags, only: %i[new create]

--- a/db/migrate/20201031005219_add_attributes_to_weekly_selections.rb
+++ b/db/migrate/20201031005219_add_attributes_to_weekly_selections.rb
@@ -1,0 +1,13 @@
+class AddAttributesToWeeklySelections < ActiveRecord::Migration[6.0]
+  def change
+    add_column :weekly_selections, :title, :string
+    add_column :weekly_selections, :published_at, :datetime
+    reversible do |dir|
+      dir.up do
+        WeeklySelection.published.find_each do |ws|
+          ws.update!(published_at: ws.created_at, title: 'TODO', description: 'TODO', description_en: 'TODO')
+        end
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -755,7 +755,9 @@ CREATE TABLE public.weekly_selections (
     description text,
     description_en text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    title character varying,
+    published_at timestamp without time zone
 );
 
 
@@ -1416,6 +1418,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201019214125'),
 ('20201021115854'),
 ('20201023130653'),
-('20201023130910');
+('20201023130910'),
+('20201031005219');
 
 


### PR DESCRIPTION
### 发布每周精选步骤

1. 书签列表中设为精选
![image](https://user-images.githubusercontent.com/16538603/97781952-b55bc980-1bc9-11eb-903a-196009681a55.png)

2. 后台管理本周精选
![image](https://user-images.githubusercontent.com/16538603/97781987-e3410e00-1bc9-11eb-9b3d-cf2ce925c497.png)

### 功能说明

1. 前台“设置精选”：给书签设置为本周精选，默认最多设置5个，如果超出了会给出提示，此时可以去后台管理已精选书签。

2. 前台“取消精选”：取消该书签的精选

3. 后台“Cancel”：取消该书签的精选

4. 后台“Titling”：设置该书签名称为本周精选名称

5. 后台“Publish”：根据填写标题和描述，按当前时间发布本周精选，发布后会出现在前台“每周精选”栏目中

### 其他说明

功能中的 “publish” 后面可以再添加邮件同步发送和公众号同步推送功能